### PR TITLE
Added OAuthAuthentication constructor with X509Certificate2 param

### DIFF
--- a/Sources/MasterCard/Core/Security/OAuth/OAuthAuthentication.cs
+++ b/Sources/MasterCard/Core/Security/OAuth/OAuthAuthentication.cs
@@ -54,6 +54,20 @@ namespace MasterCard.Core.Security.OAuth
 			}
 		}
 
+	    /// <summary>
+	    /// Create a new instance of OAuthAuthentication using the specified X509 certificate.
+	    /// </summary>
+	    /// <param name="clientId">The ClientId (Consumer Key) for MasterCard API.</param>
+	    /// <param name="x509Certificate">The X509 certificate to use for authenticating to Mastercard API via OAuth.</param>
+	    public OAuthAuthentication(String clientId,  X509Certificate2 x509Certificate)
+	    {
+	        cert = x509Certificate;
+
+	        privateKey = cert.PrivateKey;
+	        this.clientId = clientId;
+	        encoder =  new UTF8Encoding();
+	    }
+
     /// <summary>
     /// Create a new instance of OAuthAuthentication using a file path for certificate data.
     /// </summary>


### PR DESCRIPTION
This change allows us to store the certificate in our Windows certificate store without having to mark the certificate as "exportable".   

Without this constructor, we are using the constructor with the rawCertficateData parameter.   With this method, we are essentially retrieving the certificate from the Windows certificate store, which is already an X509Certificate2 object, and then calling Export on that object to get the raw certificate bytes (marked as exportable as to include the private key), and passing that into the existing OAuthAuthentication constructor that uses the raw bytes to instantiate a new X509Certificate2 object.     We'd like to pass the X509Certificate retrieved from the Windows certificate store directly and skip the export and re-instantiate steps.   In addition, not having to export to raw bytes means we don't have to mark the certificate as exportable in the windows certificate store and strengthens our security exposure.